### PR TITLE
Fix handling of `<` and `>` characters in chat messages

### DIFF
--- a/src/main/java/com/aqpfinder/AqpFinderPlugin.java
+++ b/src/main/java/com/aqpfinder/AqpFinderPlugin.java
@@ -172,6 +172,8 @@ public class AqpFinderPlugin extends Plugin implements KeyListener {
 				result.put('&',9);
 				result.put('#',11);
 				result.put('°',4);
+				result.put('<',4);
+				result.put('>',4);
 //				other
 				result.put('\u00A0',1);//no-break space
 				return Collections.unmodifiableMap(result);
@@ -268,6 +270,8 @@ public class AqpFinderPlugin extends Plugin implements KeyListener {
 		{
 			lastMessageIncludesQP = true;
 			String originalMessage = message;
+
+			message = preprocessMessage(message);
 
 			List<String> messageSegments = new ArrayList<>();
 			List<String> qpList = new ArrayList<>();
@@ -415,6 +419,27 @@ public class AqpFinderPlugin extends Plugin implements KeyListener {
 		}
 	}
 
+	/**
+	 * Preprocesses message text to convert RuneLite-escaped characters back to regular characters.
+	 *
+	 * @param message the message to preprocess
+	 * @return message with escaped characters converted to regular characters
+	 */
+	private String preprocessMessage(String message)
+	{
+		if (message == null)
+		{
+			return null;
+		}
+
+        // Taken from:
+        // https://github.com/runelite/runelite/blob/runelite-parent-1.11.15/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java#L345-L348
+		return message
+                .replace('\u00A0', ' ')
+				.replace("<lt>", "<")
+				.replace("<gt>", ">");
+	}
+	
 	/**
 	 * Returns whether the provided string contains at least one of the config enabled qp strings.
 	 *


### PR DESCRIPTION
- Add < and > character entries to pixel width map
- Add preprocessor to convert <lt> and <gt> entities back to regular characters

This fixes inconsistent recommendations when using < or > characters in messages containing QP patterns, as RuneLite converts these to <lt>/<gt> entities.

--- 

Before:

<img width="286" height="62" alt="image" src="https://github.com/user-attachments/assets/91e9f83d-05a8-4412-bda5-9324ba7248e2" />

After:

<img width="289" height="68" alt="image" src="https://github.com/user-attachments/assets/bb16165a-61c7-4c74-9562-ab55a87c07c3" />
