### PR TITLE
Prevent overlay from being cleared by irrelevant messages

### DIFF
--- a/src/main/java/com/aqpfinder/AqpFinderPlugin.java
+++ b/src/main/java/com/aqpfinder/AqpFinderPlugin.java
@@ -7,9 +7,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import lombok.Getter;
@@ -184,6 +186,18 @@ public class AqpFinderPlugin extends Plugin implements KeyListener {
 	 */
 	private final List<Character> endSentenceCharList = createEndSentenceCharList();
 
+    // Allowed message types for QP processing
+    private static final Set<ChatMessageType> ALLOWED_MESSAGE_TYPES = Collections.unmodifiableSet(
+            new HashSet<>(Arrays.asList(
+                    ChatMessageType.CLAN_CHAT,
+                    ChatMessageType.CLAN_GUEST_CHAT,
+                    ChatMessageType.PUBLICCHAT,
+                    ChatMessageType.PRIVATECHAT,
+                    ChatMessageType.PRIVATECHATOUT,
+                    ChatMessageType.FRIENDSCHAT
+            ))
+    );
+
 	/**
 	 * Creates an immutable list of characters that end a sentence in player chat.
 	 * A character is considered to end a sentence if an immediately following letter is formatted to upper case in chat.
@@ -204,6 +218,7 @@ public class AqpFinderPlugin extends Plugin implements KeyListener {
 	@Getter
 	private boolean lastMessageIncludesQP = false;
 	private boolean lastQPFromPM = false;
+    private ChatMessageType lastQPMessageType = null;
 	private Integer[] lastMessageSegmentIndex = new Integer[0];
 	private String[] lastMessageQPIndex = new String[0];
 	private String chatBoxTypedText = "";
@@ -260,7 +275,13 @@ public class AqpFinderPlugin extends Plugin implements KeyListener {
 		String message = messageNode.getValue();
 		boolean update = false;
 
-		if(lastMessageIncludesQP)
+        // Only process allowed message types
+        if(!ALLOWED_MESSAGE_TYPES.contains(messageNode.getType()))
+        {
+            return;
+        }
+
+        if(lastMessageIncludesQP && messageNode.getType().equals(lastQPMessageType))
 		{
 			lastMessageIncludesQP = false;
 			lastMessageSegmentIndex = null;
@@ -269,6 +290,7 @@ public class AqpFinderPlugin extends Plugin implements KeyListener {
 		if(containsQP(message))
 		{
 			lastMessageIncludesQP = true;
+            lastQPMessageType = messageNode.getType();
 			String originalMessage = message;
 
 			message = preprocessMessage(message);

--- a/src/main/java/com/aqpfinder/AqpFinderPlugin.java
+++ b/src/main/java/com/aqpfinder/AqpFinderPlugin.java
@@ -176,6 +176,9 @@ public class AqpFinderPlugin extends Plugin implements KeyListener {
 				result.put('°',4);
 				result.put('<',4);
 				result.put('>',4);
+                result.put('|',1);
+                result.put('%',9);
+                result.put('_',7);
 //				other
 				result.put('\u00A0',1);//no-break space
 				return Collections.unmodifiableMap(result);


### PR DESCRIPTION
For example, if a 'qp' appears in the clan chat, but an irrelevant chat message came through the public chat, the overlay disappears since it checks `plugin.isLastMessageIncludesQP()`:

```java
    public Dimension render(Graphics2D graphics)
    {
        if (!plugin.isLastMessageIncludesQP())
        {
            return null;
        }
        // ...
    }
```
https://github.com/JamesShelton140/aqp-finder/blob/master/src/main/java/com/aqpfinder/AqpFinderOverlay.java#L29-L34

which is unconditionally cleared if the previous message already had a `qp`:

```java
	@Subscribe
	public void onChatMessage(ChatMessage chatMessage)
	{
        //...

		if(lastMessageIncludesQP)
		{
			lastMessageIncludesQP = false;
			lastMessageSegmentIndex = null;
		}

        //...
    }
```
https://github.com/JamesShelton140/aqp-finder/blob/master/src/main/java/com/aqpfinder/AqpFinderPlugin.java#L263-L267

This change makes it so that existing buffers are cleared if and only if a subsequent message came through from the same chat origin (public chat, friends chat, clan chat, etc).

As an aside, I've also made it so that the plugin handles specific chat types only, which would've been a better fix for #5, I think. 
